### PR TITLE
userコントローラーのエンドポイント作成

### DIFF
--- a/app/controllers/api/v1/authentication_controller.rb
+++ b/app/controllers/api/v1/authentication_controller.rb
@@ -1,0 +1,33 @@
+class Api::V1::AuthenticationController < ApplicationController
+  require 'jwt'
+  def login
+    user = User.find_by(email: params[:email])
+    if user&.authenticate(params[:password])
+      token = TokenGenerator.encode(user.id)
+      cookies[:jwt] = {
+        value: token,
+        expires: 24.hours.from_now,
+        secure: Rails.env.production?,
+        httponly: true,
+        same_site: :none
+      }
+      render json: { name: user.name, email: user.email  }
+    else
+      render json: { status: "メールアドレスかパスワードが間違っています。" }, status: :unprocessable_entity
+    end
+  end
+
+  def logout
+    cookies.delete(:jwt)
+    render json: { message: 'ログアウトしました' }, status: :ok
+  end
+
+  def show_request
+    token = cookies[:jwt]
+    decode = TokenGenerator.decode(token)['token']
+    user = User.find_by(id: decode)
+
+
+    render json: { name: user.name, email: user.email }
+  end
+end

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -2,19 +2,24 @@ class Api::V1::UsersController < ApplicationController
   def create
     user = User.new(user_params)
     if user.save 
-      token = TokenGenerator.encode(user) if user.save
-      
+
+      token = TokenGenerator.encode(user.id)
       cookies[:jwt] = {
         value: token,
-        expire: 24.hours.from_now,
+        expires: 24.hours.from_now,
         secure: Rails.env.production?,
-        httponly: true
+        httponly: true,
+        same_site: :none
       }
-    render json: { status: "ユーザーの登録に成功しました" }
+
+      render json: { status: "ユーザーの登録に成功しました" }
     else
       render json: { error: "ユーザーの登録に失敗しました" }, status: :unprocessable_entity
     end
   end
+
+
+
 
   private 
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,5 @@
 class ApplicationController < ActionController::API
   include ActionController::Cookies
+
+
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,8 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       post "recipe_generations", to: "recipe_generations#create"
+      post "login", to: "authentication#login"
+      get "show_request", to: "authentication#show_request"
       resources :users, only: %i( create )
       resources :vegetables, only: %i( index show )
     end

--- a/test/controllers/api/v1/authentication_controller_test.rb
+++ b/test/controllers/api/v1/authentication_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class Api::V1::AuthenticationControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
新規登録とログイン用のエンドポイントを作成
jwtのpayloadにuser.idを保存して、cookieでクライアント側に送信する。