### PR TITLE
買い物リスト追加用のエンドポイント実装完了

### DIFF
--- a/app/controllers/api/v1/recipes_controller.rb
+++ b/app/controllers/api/v1/recipes_controller.rb
@@ -1,0 +1,21 @@
+class Api::V1::RecipesController < ApplicationController
+  before_action :authenticate_user!
+
+  def create
+    recipe_data = recipe_params
+    result = ShoppingListCreator.new(@current_user, recipe_data).call
+
+    if result[:success]
+      render json: { success: true, recipe: result[:recipe]}, status: :created
+    else
+      render json: { success: false, error: result[:error]}, status: :unprocessable_entity
+    end
+  end
+end
+
+
+private 
+
+def recipe_params
+  params.permit(:name, :instructions, :cooking_time, :difficulty, :servings, ingredients: [:name, :amount, :unit], step: [:step_number, :description])
+end

--- a/app/controllers/api/v1/shopping_lists_controller.rb
+++ b/app/controllers/api/v1/shopping_lists_controller.rb
@@ -1,0 +1,21 @@
+class Api::V1::ShoppingListsController < ApplicationController
+  before_action :authenticate_user!
+  
+  def create
+    recipe_data = recipe_params
+    result = ShoppingListCreator.new(@current_user, recipe_data).call
+    shopping_list = result[:shopping_list]
+
+    if result[:success]
+      render json: ShoppingListSerializer.new(shopping_list).serializable_hash.to_json
+    else
+      render json: {success: false, error: result[:error]}, status: :unprocessable_entity
+    end
+  end
+
+  private 
+
+  def recipe_params
+    params.permit(:name, :instructions, :cooking_time, :difficulty, :servings, ingredients: [:name, :amount, :unit], step: [:step_number, :description])
+  end
+end

--- a/app/models/ingredient.rb
+++ b/app/models/ingredient.rb
@@ -1,4 +1,4 @@
 class Ingredient < ApplicationRecord
   belongs_to :recipe
-  has_many :shopping_list_items
+  has_many :shopping_list_items, dependent: :destroy
 end

--- a/app/models/recipe.rb
+++ b/app/models/recipe.rb
@@ -1,6 +1,7 @@
 class Recipe < ApplicationRecord
   belongs_to :user
-  has_many :ingredients
-  has_many :recipe_steps
-  has_many :shopping_list_items
+  has_many :ingredients, dependent: :destroy
+  has_many :recipe_steps, dependent: :destroy
+  has_many :shopping_list_items, dependent: :destroy
+  has_many :shopping_lists, through: :shopping_list_items
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,7 @@
 class User < ApplicationRecord
   has_secure_password
+  has_many :recipes
+  has_many :shopping_lists
   validates :name, presence: { message: '名前の入力は必須です' }
   validates :email, presence: { message: 'メールアドレスの入力は必須です'}, uniqueness: { message: 'このメールアドレスはすでに使用されています'}, format: { with: URI::MailTo::EMAIL_REGEXP, message: '無効なメールアドレスです' } 
   validates :password, presence: { message: 'パスワードの入力は必須です'}, length: { minimum: 8, message: '８文字以上で入力してください' }

--- a/app/serializers/shopping_list_serializer.rb
+++ b/app/serializers/shopping_list_serializer.rb
@@ -1,0 +1,16 @@
+class ShoppingListSerializer
+  include JSONAPI::Serializer
+  
+  attributes :id, :name
+
+  attribute :shopping_items do |shopping_list|
+    shopping_list.shopping_list_items.map do |item|
+      {
+        name: item.ingredient.name,
+        amount: item.ingredient.amount,
+        unit: item.ingredient.unit,
+        checked: item.checked
+      }
+    end
+  end
+end

--- a/app/services/gemini_client.rb
+++ b/app/services/gemini_client.rb
@@ -50,6 +50,7 @@ class GeminiClient
     }
 
     response = self.class.post("", options).parsed_response
+    Rails.logger.info("Gemini API response: #{response}")
     text_block = response["candidates"][0]["content"]["parts"][0]["text"]
     text = text_block.match(/```json\n(.*)\n```/m)[1] rescue "{}"
     return text

--- a/app/services/shopping_list_creator.rb
+++ b/app/services/shopping_list_creator.rb
@@ -1,0 +1,44 @@
+class ShoppingListCreator
+  def initialize(current_user, recipe_data)
+    @current_user = current_user
+    @recipe_data = recipe_data
+  end
+
+  def call
+    ActiveRecord::Base.transaction do
+      recipe = create_recipe
+
+      if recipe.persisted?
+        shopping_list = add_to_shopping_list(recipe)
+        return { success: true, shopping_list: shopping_list }
+      else
+        raise ActiveRecord::Rollback, 'レシピ作成に失敗しました'
+      end
+    end
+  rescue => e 
+    { success: false, error: e.message }
+  end
+
+  private 
+
+  def create_recipe
+    recipe = @current_user.recipes.find_or_create_by(@recipe_data.except(:ingredients, :step))
+    @recipe_data[:ingredients].each do |ingredient|
+      recipe.ingredients.create(ingredient)
+    end
+
+    @recipe_data[:step].each do |step|
+      recipe.recipe_steps.create(step)
+    end
+    return recipe
+  end
+
+  def add_to_shopping_list(recipe)
+    shopping_list = @current_user.shopping_lists.find_or_create_by(name: '買い物リスト')
+
+    recipe.ingredients.each do |ingredient|
+      shopping_list.shopping_list_items.create!(ingredient: ingredient, recipe: recipe)
+    end
+    return shopping_list
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,8 @@ Rails.application.routes.draw do
       post "logout", to: 'authentication#logout'
       get 'check_login_status', to: 'authentication#check_login_status'
       get "show_request", to: "authentication#show_request"
+      resources :shopping_lists, only: %i( create )
+      resources :recipes, only: %i( create )
       resources :users, only: %i( create )
       resources :vegetables, only: %i( index show )
     end

--- a/db/migrate/20250430124737_change_amount_to_string_in_ingredients.rb
+++ b/db/migrate/20250430124737_change_amount_to_string_in_ingredients.rb
@@ -1,0 +1,5 @@
+class ChangeAmountToStringInIngredients < ActiveRecord::Migration[7.2]
+  def change
+    change_column :ingredients, :amount, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,14 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_04_29_102910) do
+ActiveRecord::Schema[7.2].define(version: 2025_04_30_124737) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "ingredients", force: :cascade do |t|
     t.bigint "recipe_id", null: false
     t.string "name"
-    t.float "amount"
+    t.string "amount"
     t.string "unit"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/test/controllers/api/v1/recipes_controller_test.rb
+++ b/test/controllers/api/v1/recipes_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class Api::V1::RecipesControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/controllers/api/v1/shopping_lists_controller_test.rb
+++ b/test/controllers/api/v1/shopping_lists_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class Api::V1::ShoppingListsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
フロントの買い物追加ボタンからのエンドポイントを作成

リクエストデータのレシピ情報をrecipeテーブルと関連テーブルおよび
shopping_listテーブルとshopping_list_itemsテーブルに保存するサービスクラスを実装した。

また、controllerにshopping_listコントローラーを追加して、登録した材料リストを
レスポンスデータに含めて送る設計とした。