### PR TITLE
recipe_idのforeignkeyの解除

### DIFF
--- a/db/migrate/20250519133621_remove_recipe_fk_from_ingredients_and_shopping_items.rb
+++ b/db/migrate/20250519133621_remove_recipe_fk_from_ingredients_and_shopping_items.rb
@@ -1,0 +1,10 @@
+class RemoveRecipeFkFromIngredientsAndShoppingItems < ActiveRecord::Migration[7.2]
+  def change
+
+    remove_foreign_key :ingredients, :recipes if foreign_key_exists?(:ingredients, :recipes)
+    remove_foreign_key :shopping_list_items, :recipes if foreign_key_exists?(:shopping_list_items, :recipes)
+
+    change_column_null :ingredients, :recipe_id, true
+    change_column_null :shopping_list_items, :recipe_id, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,12 +10,12 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_05_17_111825) do
+ActiveRecord::Schema[7.2].define(version: 2025_05_19_133621) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "ingredients", force: :cascade do |t|
-    t.bigint "recipe_id", null: false
+    t.bigint "recipe_id"
     t.string "name"
     t.string "amount"
     t.string "unit"
@@ -82,7 +82,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_05_17_111825) do
 
   create_table "shopping_list_items", force: :cascade do |t|
     t.bigint "shopping_list_id", null: false
-    t.bigint "recipe_id", null: false
+    t.bigint "recipe_id"
     t.bigint "ingredient_id", null: false
     t.boolean "checked", default: false
     t.datetime "created_at", null: false
@@ -132,13 +132,11 @@ ActiveRecord::Schema[7.2].define(version: 2025_05_17_111825) do
     t.index ["name"], name: "index_vegetables_on_name", unique: true
   end
 
-  add_foreign_key "ingredients", "recipes"
   add_foreign_key "prices", "vegetables"
   add_foreign_key "recipe_steps", "recipes"
   add_foreign_key "recipes", "users"
   add_foreign_key "seasons", "vegetables"
   add_foreign_key "shopping_list_items", "ingredients"
-  add_foreign_key "shopping_list_items", "recipes"
   add_foreign_key "shopping_list_items", "shopping_lists"
   add_foreign_key "shopping_lists", "users"
   add_foreign_key "vegetable_nutritions", "nutrition_types"


### PR DESCRIPTION
shopping_list_itemsにrecipeに関連付けないingredientsを登録するために、
shopping_list_itemsとingredientsテーブルに登録されていたreciep_idのforeign_key制約を解除した。
また、null:falseとなっていたため、null:tureで空白を許可する制約に変更した。