### PR TITLE
shopping_list_itemsのcreate,destroyアクションの実装完了

### DIFF
--- a/app/controllers/api/v1/shopping_list_items_controller.rb
+++ b/app/controllers/api/v1/shopping_list_items_controller.rb
@@ -1,0 +1,42 @@
+class Api::V1::ShoppingListItemsController < ApplicationController
+  def create
+    shopping_list = @current_user.shopping_lists.find_by(id: params[:shopping_list_id])
+
+    if shopping_list.nil?
+      render json: { status: 'failed', message: '買い物リストが見つかりませんでした' }, status: :not_found
+    end
+
+    ingredient = Ingredient.create!(new_item_params)
+
+    item = shopping_list.shopping_list_items.new(
+      ingredient: ingredient,
+    )
+
+    if item.save
+      render json: { status: 'success', message: 'ショッピングアイテムの追加に成功しました', item: item.ingredient }, status: :created
+    else
+      render json: { status: 'failed', message: 'アイテムの保存に失敗しました', errors: item.errors.full_messages }, status: :unprocessable_entity 
+    end
+  end
+
+  def destroy
+    shopping_list_item = ShoppingListItem.find_by(id: params[:id])
+    if shopping_list_item.nil?
+      render json: { status: 'failed', message: '該当のアイテムが見つかりませんでした' }, status: :not_found
+      return
+    end
+
+    if shopping_list_item.destroy
+      render json: { status: 'success', message: 'アイテムの削除に成功しました' }, status: :ok
+    else
+      render json: { status: 'failed', message: 'アイテムの削除に失敗しました' }, status: :unprocessable_entity
+    end
+  end
+    
+
+  private
+
+  def new_item_params
+    params.permit(:name, :display_amount, :category)
+  end
+end

--- a/app/models/ingredient.rb
+++ b/app/models/ingredient.rb
@@ -1,4 +1,4 @@
 class Ingredient < ApplicationRecord
-  belongs_to :recipe
+  belongs_to :recipe, optional: true
   has_many :shopping_list_items, dependent: :destroy
 end

--- a/app/models/shopping_list_item.rb
+++ b/app/models/shopping_list_item.rb
@@ -1,5 +1,16 @@
 class ShoppingListItem < ApplicationRecord
   belongs_to :shopping_list
-  belongs_to :recipe
+  belongs_to :recipe, optional: true
   belongs_to :ingredient
+  after_destroy :cleanup_ingredient
+
+  private
+
+    def cleanup_ingredient
+      ingredient.reload
+
+      if ingredient.shopping_list_items.empty? && ingredient.recipe.nil?
+        ingredient.destroy
+      end
+    end
 end

--- a/app/serializers/shopping_list_serializer.rb
+++ b/app/serializers/shopping_list_serializer.rb
@@ -12,12 +12,11 @@ class ShoppingListSerializer
       {
         id: item.ingredient.id,
         name: item.ingredient.name,
-        amount: item.ingredient.amount,
-        unit: item.ingredient.unit,
         display_amount: item.ingredient.display_amount,
         category: item.ingredient.category,
-        checked: item.checked,
-        fromRecipe: item.recipe.name,
+        checked: item&.checked,
+        fromRecipe: item.recipe&.name,
+        item_id: item.id 
       }
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,7 +15,9 @@ Rails.application.routes.draw do
       get "show_request", to: "authentication#show_request"
       resources :shopping_lists, only: %i( index show create update destroy ) do
         post :from_recipe, on: :collection
+        resources :shopping_list_items, shallow: true
       end
+
       resources :recipes, only: %i( index show create destroy )
 
       resources :users, only: %i( create )

--- a/test/controllers/api/v1/shopping_list_items_controller_test.rb
+++ b/test/controllers/api/v1/shopping_list_items_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class Api::V1::ShoppingListItemsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
shopping_list_itemsのコントローラーを実装した。
アイテムの追加と削除のアクションをそれぞれ実装している。

なお、destroyアクションはshopping_list_itemsにafter_destroyのコールバックで
ingredient.shopping_list_items.empty? && ingredient.recipe.nil?の場合は
shopping_list_item削除時にingredientも削除している。
（createアクションで追加したingredientはshopping_list_itemsともレシピとも紐づかなくなるため
　削除しないと使われないレコードが残ってしまう）