### PR TITLE
batch_updateを実装

### DIFF
--- a/app/controllers/api/v1/shopping_list_items_controller.rb
+++ b/app/controllers/api/v1/shopping_list_items_controller.rb
@@ -13,9 +13,26 @@ class Api::V1::ShoppingListItemsController < ApplicationController
     )
 
     if item.save
-      render json: { status: 'success', message: 'ショッピングアイテムの追加に成功しました', item: item.ingredient }, status: :created
+      render json: { status: 'success', message: 'ショッピングアイテムの追加に成功しました', item: item.ingredient.as_json.merge(item_id: item.id) }, status: :created
     else
       render json: { status: 'failed', message: 'アイテムの保存に失敗しました', errors: item.errors.full_messages }, status: :unprocessable_entity 
+    end
+  end
+
+  def update
+    shopping_list_item = ShoppingListItem.find_by(id: params[:id])
+    
+    if shopping_list_item.nil?
+      render json: { status: 'failed', message: '当該のアイテムが見つかりませんでした' }, status: :not_found
+      return
+    end
+
+    checked = ActiveModel::Type::Boolean.new.cast(params[:checked])
+
+    if shopping_list_item.update(checked: checked)
+      render json: { status: 'success', message: 'アイテムの更新に成功しました' }, status: :ok
+    else
+      render json: { status: 'failed', message: 'アイテムの更新に失敗しました' }, status: :unprocessable_entity
     end
   end
 
@@ -32,11 +49,48 @@ class Api::V1::ShoppingListItemsController < ApplicationController
       render json: { status: 'failed', message: 'アイテムの削除に失敗しました' }, status: :unprocessable_entity
     end
   end
+
+  def batch_update
+    updates = update_params
+    if updates.blank?
+      return render json: { status: 'failed', message: 'リクエストデータがありません' }, status: :unprocessable_entity
+    end
+
+    errors = []
+
+    ActiveRecord::Base.transaction do
+      updates.each do |item|
+        shopping_list_item = ShoppingListItem.find_by(id: item[:id])
+        unless shopping_list_item
+          errors << "ID #{item[:id]}が見つかりませんでした"
+          next
+        end
+
+        unless shopping_list_item.update(checked: item[:checked])
+          errors << "ID #{item[:id]}の更新に失敗しました"
+        end
+
+        raise ActiveRecord::Rollback if errors.any?
+      end
+
+      if errors.any?
+        render json: { status: 'failed', message: '一部または全ての更新に失敗しました', errors: errors }, status: :unprocessable_entity
+      else
+        render json: { status: 'success' }, status: :ok
+      end
+    end
+  end
     
 
   private
 
   def new_item_params
     params.permit(:name, :display_amount, :category)
+  end
+
+  def update_params
+    params.require(:updates).map do |item|
+      item.permit(:id, :checked)
+    end
   end
 end

--- a/app/controllers/api/v1/shopping_lists_controller.rb
+++ b/app/controllers/api/v1/shopping_lists_controller.rb
@@ -22,22 +22,6 @@ class Api::V1::ShoppingListsController < ApplicationController
     end
   end
 
-  def update
-    ActiveRecord::Base.transaction do
-      shopping_list_items = @current_user.shopping_lists.find_by(id: params[:id]).shopping_list_items
-      update_items = update_items_params.index_by {|item| item["id"]}
-  
-      shopping_list_items.each do |item|
-        if update_items[item.ingredient_id]
-          checked_value = update_items[item.ingredient_id]["checked"]
-          item.update!(checked: checked_value)
-        end
-      end
-    end
-    render json: {success: "更新に成功しました"}, status: :ok
-  rescue => e
-    render json: { error: "エラーが発生しました: #{e.message}" }, status: :internal_server_error
-  end
 
   def destroy
     shopping_list = @current_user.shopping_lists.find_by(id: params[:id])

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,7 +15,9 @@ Rails.application.routes.draw do
       get "show_request", to: "authentication#show_request"
       resources :shopping_lists, only: %i( index show create update destroy ) do
         post :from_recipe, on: :collection
-        resources :shopping_list_items, shallow: true
+        resources :shopping_list_items, shallow: true do
+          patch :batch_update, on: :collection
+        end
       end
 
       resources :recipes, only: %i( index show create destroy )


### PR DESCRIPTION
shopping_listでcheckedの変更を反映するエンドポイントを実装
useEffectのsetIntervalでポーリングでリクエストを送るため、
更新するitem項目が複数ある。
そのため、updateアクションの単体の更新では処理できないため、
batch_updateアクションをcollectionでroute定義した。

ActiveRecored::Base.transaction内でerrors配列を定義して、
エラーが発生するたびに配列に追加している。

最終的にerros配列に値があれば、ActiveRecord::Rollbackで巻き戻し処理を実行している
なお、ActiveRecord::Rollbackは例外処理にならず、そのまま処理は続行するため、
失敗時のerrorsはフロントにレスポンスしている。