### PR TITLE
レシピから買い物リストへの材料追加機能の実装完了

### DIFF
--- a/app/controllers/api/v1/shopping_lists_controller.rb
+++ b/app/controllers/api/v1/shopping_lists_controller.rb
@@ -43,17 +43,20 @@ class Api::V1::ShoppingListsController < ApplicationController
 
   def from_recipe
     recipe = @current_user.recipes.find_by(id: params[:recipe_id])
-    
     return render json: { message: 'レシピが見つかりません' }, status: :not_found if recipe.blank?
 
     ActiveRecord::Base.transaction do
-      shopping_list = @current_user.shopping_lists.create!(name: recipe.name)
+      if params[:shopping_list_id].present?
+        shopping_list = @current_user.shopping_lists.find_by(id: params[:shopping_list_id])
+      else
+        shopping_list = @current_user.shopping_lists.create!(name: params[:name])
+      end
       recipe.ingredients.each do |ingredient|
         shopping_list.shopping_list_items.create!(recipe: recipe, ingredient: ingredient)
       end
     end
 
-    render json: { message: '買い物リストの作成に成功しました' }, status: :created
+    render json: RecipeSerializer.new(recipe).serializable_hash, status: :created
   rescue => e
     render json: { message: '買い物リストの作成に失敗しました', error: e.message }, status: :unprocessable_entity
   end

--- a/app/models/shopping_list.rb
+++ b/app/models/shopping_list.rb
@@ -3,4 +3,10 @@ class ShoppingList < ApplicationRecord
   has_many :shopping_list_items, dependent: :destroy
   has_many :recipes, through: :shopping_list_items
   has_many :ingredients, through: :shopping_list_items
+
+  def updated_days_ago
+    return nil if updated_at.nil?
+    days = (Time.zone.today - updated_at.to_date).to_i
+    days.zero? ? '今日' : "#{days}日前"
+  end
 end

--- a/app/serializers/recipe_serializer.rb
+++ b/app/serializers/recipe_serializer.rb
@@ -30,6 +30,10 @@ class RecipeSerializer
       {
         id: list.id,
         name: list.name,
+        updated: list.updated_days_ago,
+        items_count: list.shopping_list_items.count,
+        checked_count: list.shopping_list_items.where(checked: true).count,
+        already_added: list.shopping_list_items.exists?(recipe_id: recipe.id)
       }
     end
   end


### PR DESCRIPTION
from_recipeコントローラーをshopping_list_idの有無で処理を分けた。
nameがある場合は新規でshopping_listを作成している。

already_addはshopping_listsと紐づく、shopping_list_itemsに
開いているレシピのrecipe_idがあるもの
つまり、すでにレシピの材料追加がされている場合はtrueを返している。
フロントでtrueの場合はボタンのdisabledにするために使用している。