### PR TITLE
冷蔵庫に材料追加時にamountの合算をするように変更

### DIFF
--- a/app/controllers/api/v1/fridge_items_controller.rb
+++ b/app/controllers/api/v1/fridge_items_controller.rb
@@ -25,9 +25,29 @@ class Api::V1::FridgeItemsController < ApplicationController
 
     ActiveRecord::Base.transaction do
       items.each do |item|
-        days = category_expire_days[item[:category]] || 3
-        expire_date = Date.today + days
-        @current_user.fridge_items.create!(name: item[:name], category: item[:category], expire_date: expire_date, display_amount: item[:display_amount])
+        if item[:expire_date].blank?
+          days = category_expire_days[item[:category]] || 3
+          expire_date = Time.zone.today + days
+        end
+
+        if item[:category] == '調味料'
+          @current_user.fridge_items.find_or_create_by(name: item[:name], category: item[:category])
+        else
+          existing_item = @current_user.fridge_items.find_by(name: item[:name], category: item[:category])
+          if existing_item.present? && existing_item.unit == item[:unit]
+            before_amount = existing_item.amount.to_i
+            new_amount = item[:amount].to_i
+            total_amount = before_amount + new_amount
+            if total_amount <= 0
+              display_amount = nil
+            else
+              display_amount = "#{total_amount}#{existing_item.unit}"
+            end
+            existing_item.update!(display_amount: display_amount, amount: total_amount)
+          else
+            @current_user.fridge_items.create!(name: item[:name], category: item[:category], expire_date: expire_date || item[:expire_date], display_amount: item[:display_amount], amount: item[:amount], unit: item[:unit])
+          end
+        end
       end
     end
     fridge_items = @current_user.fridge_items
@@ -66,7 +86,7 @@ class Api::V1::FridgeItemsController < ApplicationController
   def fridge_items_params
     fridge_array = params[:fridge]
     fridge_array.map do |item|
-      item.permit(:name, :category, :display_amount, :expire_date)
+      item.permit(:name, :category, :display_amount, :expire_date, :amount, :unit)
     end
   end
 

--- a/app/models/fridge_item.rb
+++ b/app/models/fridge_item.rb
@@ -1,8 +1,10 @@
 class FridgeItem < ApplicationRecord
   belongs_to :user
+  validates :name, presence: true
+  validates :category, presence: true
 
   def expire_status
-    return 'expired' if expire_date.nil?
+    return 'unset' if expire_date.nil?
 
     today = Date.today
     limit_day = (expire_date - today).to_i

--- a/app/serializers/shopping_list_serializer.rb
+++ b/app/serializers/shopping_list_serializer.rb
@@ -16,7 +16,9 @@ class ShoppingListSerializer
         category: item.ingredient.category,
         checked: item&.checked,
         fromRecipe: item.recipe&.name,
-        item_id: item.id 
+        item_id: item.id,
+        amount: item.ingredient.amount,
+        unit: item.ingredient.unit,
       }
     end
   end


### PR DESCRIPTION
Fridge_itmesコントローラーのcreateアクションを以下の通り変更した。

調味料の登録時はname, categoryのみで登録
（調味料の賞味期限は長期間かつばらつきがあるため）

その他のカテゴリを登録時は新規であればcreateで作成
既存のデータで同名、同カテゴリーで同unit名であれば
amountの値を既存の数値に合算してdisplay_amountを更新するように

