### PR TITLE
url生成メソッドの変更

### DIFF
--- a/app/controllers/api/v1/recipe_image_generations_controller.rb
+++ b/app/controllers/api/v1/recipe_image_generations_controller.rb
@@ -16,7 +16,7 @@ class Api::V1::RecipeImageGenerationsController < ApplicationController
     temp_image.image.attach(io: io, filename: 'generated.png', content_type: 'image/png')
     temp_image.save!
 
-    render json: { temp_image_id: temp_image.id, image_url: url_for(temp_image.image)}
+    render json: { temp_image_id: temp_image.id, image_url: rails_blob_url(temp_image.image, host:"localhost:3000")}
 
   end
 end


### PR DESCRIPTION
ActiveStorageのデータurlをフロントに返す場合にはurl_forではなく
rails_blob_url（active_storage専用メソッド)の方が完全なURLを生成するため
変更。
（url_forは内部的に判断して完全pathを返すため、動作不良を起こす可能性がある）

なお、encirnmentで
Rails.application.routes.default_url_options[:host] = 'https://localhost:3000'
を設定していればhost:の指定は不要、かつ開発環境でのホストとIPアドレスを指定できる