### PR TITLE
料理画像データの一時保存方法の変更

### DIFF
--- a/app/controllers/api/v1/recipe_image_generations_controller.rb
+++ b/app/controllers/api/v1/recipe_image_generations_controller.rb
@@ -16,10 +16,8 @@ class Api::V1::RecipeImageGenerationsController < ApplicationController
     file.write(decode)
     file.rewind
 
-    temp_image = TempImage.new
-    temp_image.image.attach(io: file, filename: 'generated.png', content_type: 'image/png')
-    temp_image.save!
+    blob = ActiveStorage::Blob.create_and_upload!(io: file, filename: 'generated.png', content_type: 'image/png')
 
-    render json: { temp_image_id: temp_image.id, image_url: rails_blob_url(temp_image.image)}
+    render json: { image_id: blob.signed_id, image_url: rails_blob_url(blob)}
   end
 end

--- a/app/controllers/api/v1/recipes_controller.rb
+++ b/app/controllers/api/v1/recipes_controller.rb
@@ -40,6 +40,6 @@ class Api::V1::RecipesController < ApplicationController
   private 
 
   def recipe_params
-    params.except(:recipe).permit( :name, :calorie, :recipe_category, :cooking_method, :instructions, :cooking_time, :purpose, :servings, :temp_image_id, ingredients: [:name, :amount, :unit, :display_amount, :category], step: [:step_number, :description])
+    params.except(:recipe).permit( :name, :calorie, :recipe_category, :cooking_method, :instructions, :cooking_time, :purpose, :servings, :image_id, ingredients: [:name, :amount, :unit, :display_amount, :category], step: [:step_number, :description])
   end
 end

--- a/app/jobs/purge_unattached_blob_job.rb
+++ b/app/jobs/purge_unattached_blob_job.rb
@@ -1,0 +1,9 @@
+class PurgeUnattachedBlobJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    ActiveStorage::Blob.unattached.find_each do |blob|
+      blob.purge
+    end
+  end
+end

--- a/app/models/recipe.rb
+++ b/app/models/recipe.rb
@@ -4,5 +4,12 @@ class Recipe < ApplicationRecord
   has_many :recipe_steps, dependent: :destroy
   has_many :shopping_list_items, dependent: :destroy
   has_many :shopping_lists, through: :shopping_list_items
-  has_one_attached :image, dependent: :purge
+  has_one_attached :image
+  before_destroy :purge_image
+
+  private
+
+  def purge_image
+    image.purge_later if image.attached?
+  end
 end

--- a/app/services/recipe_creator.rb
+++ b/app/services/recipe_creator.rb
@@ -6,7 +6,7 @@ class RecipeCreator
 
   def call
     ActiveRecord::Base.transaction do
-      user_recipe = @current_user.recipes.create!(@recipe_data.except(:ingredients, :step, :temp_image_id))
+      user_recipe = @current_user.recipes.create!(@recipe_data.except(:ingredients, :step, :image_id))
       
       @recipe_data[:ingredients].each do |ingredient|
         user_recipe.ingredients.create!(ingredient)
@@ -16,10 +16,14 @@ class RecipeCreator
         user_recipe.recipe_steps.create!(step)
       end
 
-      temp = TempImage.find_by(id: @recipe_data[:temp_image_id])
-      if temp
-        user_recipe.image.attach(temp.image.blob)
+      if @recipe_data[:image_id].present?
+        blob = ActiveStorage::Blob.find_signed(@recipe_data[:image_id])
+        user_recipe.image.attach(blob)
       end
     end
+
+  rescue => e 
+    Rails.logger.error("レシピ作成中のエラー: #{e.message}")
+    raise
   end
 end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -9,8 +9,8 @@ end
 # 例：config/initializers/sidekiq.rb
 Sidekiq::Scheduler.dynamic = true
 
-schedule_file = "config/sidekiq_scheduler.yml"
+# schedule_file = "config/sidekiq_scheduler.yml"
 
-if File.exist?(schedule_file) && Sidekiq.server?
-  Sidekiq::Scheduler.load_schedule!
-end
+# if File.exist?(schedule_file) && Sidekiq.server?
+#   Sidekiq::Scheduler.load_schedule!
+# end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -3,8 +3,6 @@
   - default
 
 :timeout: 25
-:logfile: ./log/sidekiq.log
-:pidfile: ./tmp/pids/sidekiq.pid
 
 :redis:
   url: redis://redis:6379/0
@@ -19,3 +17,7 @@
     export_prices_to_csv:
       cron: "0 23 * * 2"
       class: ExportPricesToCsvJob
+
+    purge_unattached_blob:
+      cron: "0 0 * * *"
+      class: PurgeUnattachedBlobJob

--- a/test/jobs/purge_unattached_blob_job_test.rb
+++ b/test/jobs/purge_unattached_blob_job_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class PurgeUnattachedBlobJobTest < ActiveJob::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
従来はGeminiAPIを叩いてレスポンスされた画像データ（base64）はTempImageに一時保存していたが、
ActiveStorage::Blob.create_and_upload!(io: バイナリ, filename: ~, content_tyep: 'image/png')で
Blobに直接保存できることが判明したので、こちらの保存方法に変更した。

create_and_upload!で保存処理をしたさいにblobオブジェクトをレスポンスするので、
フロントにはblob.signed_id(idをそのまま渡さず署名したid）とimage_urlをレスポンスしている。
フロントで保存処理をする場合にはblob_singed_idをつけてリクエストし、
バックエンドでActiveStorage::Blob.find_signedで該当レコードを確認し、image.attachで関連付けを行う。

なお、フロントで保存したかったblobについてはjobで削除処理を行う。
attachされていないblobはActiveStorage::Blob.unattachedで取得できるので、
そのリレーションデータをfind_eachで取得してpurgeを行う。

