### PR TITLE
Rdisの追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,7 @@ gem 'googleauth', '~> 1.14'
 gem 'google-api-client', '~> 0.53.0'
 gem 'cloudinary'
 gem 'activestorage-cloudinary-service'
+gem 'redis'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -293,6 +293,10 @@ GEM
     rake (13.2.1)
     rdoc (6.13.1)
       psych (>= 4.0.0)
+    redis (5.4.1)
+      redis-client (>= 0.22.0)
+    redis-client (0.25.1)
+      connection_pool
     regexp_parser (2.10.0)
     reline (0.6.1)
       io-console (~> 0.5)
@@ -403,6 +407,7 @@ DEPENDENCIES
   puma (>= 5.0)
   rack-cors
   rails (~> 7.2.2, >= 7.2.2.1)
+  redis
   rspec-rails
   rubocop-rails-omakase
   shoulda-matchers

--- a/app/models/price.rb
+++ b/app/models/price.rb
@@ -3,30 +3,27 @@ class Price < ApplicationRecord
   validates :price, :market, :date, presence: true
 
   scope :vegetable_ids_with_price_drop, -> {
-    subquery = <<-SQL.squish
-      WITH ranked_prices AS (
-        SELECT
-          vegetable_id,
-          price,
-          ROW_NUMBER() OVER (PARTITION BY vegetable_id ORDER BY date DESC) AS rn
-        FROM prices
-      ),
-      latest_two_prices AS (
-        SELECT
-          p1.vegetable_id,
-          p1.price AS latest_price,
-          p2.price AS previous_price
-        FROM ranked_prices p1
-        LEFT JOIN ranked_prices p2
-          ON p1.vegetable_id = p2.vegetable_id AND p2.rn = 2
-        WHERE p1.rn = 1
-      )
-      SELECT vegetable_id FROM latest_two_prices
-      WHERE previous_price IS NOT NULL AND latest_price < previous_price
-    SQL
-
-    # サブクエリ結果のvegetable_idを配列で返す
-    Price.connection.select_values(subquery)
+    Rails.cache.fetch("price_drop_vegetable_ids", expires_in: 1.hour) do
+      subquery = <<-SQL.squish
+        SELECT DISTINCT p1.vegetable_id
+        FROM prices p1
+        INNER JOIN prices p2 ON p1.vegetable_id = p2.vegetable_id
+        WHERE p1.date = (
+          SELECT MAX(date)
+          FROM prices
+          WHERE vegetable_id = p1.vegetable_id
+        )
+        AND p2.date = (
+          SELECT MAX(date)
+          FROM prices
+          WHERE vegetable_id = p2.vegetable_id
+          AND date < p1.date
+        )
+        AND p1.price < p2.price
+      SQL
+      # サブクエリ結果のvegetable_idを配列で返す
+      Price.connection.select_values(subquery)
+    end
   }
 
   def self.monthly_average_for(vegetable_id)

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -61,7 +61,10 @@ Rails.application.configure do
   config.log_level = ENV.fetch("RAILS_LOG_LEVEL", "info")
 
   # Use a different cache store in production.
-  # config.cache_store = :mem_cache_store
+  config.cache_store = :redis_cache_store, {
+    url: ENV['REDIS_URL'],
+    ssl_params: { verify_mode: OpenSSL::SSL::VERIFY_PEER }
+  }
 
   # Use a real queuing backend for Active Job (and separate queues per environment).
   # config.active_job.queue_adapter = :resque


### PR DESCRIPTION
値下がりした野菜価格のIDを出力するSQLを見直した。
結果をキャッシュするために、upstashのRedisを使用する。
(Rails.cache.feath('key', expire: data) do
sql
end
