### PR TITLE
feat: 認証機能の改善とCORS設定の更新

### DIFF
--- a/app/controllers/api/v1/auth_controller.rb
+++ b/app/controllers/api/v1/auth_controller.rb
@@ -2,7 +2,6 @@ require "googleauth/id_tokens"
 require "httparty"
 
 class Api::V1::AuthController < ApplicationController
-
   def google_login
     auth_code = params[:code]
     return render json: { error: '認証コードが見つかりません' }, status: :bad_request if auth_code.blank?

--- a/app/controllers/api/v1/authentication_controller.rb
+++ b/app/controllers/api/v1/authentication_controller.rb
@@ -1,8 +1,8 @@
 class Api::V1::AuthenticationController < ApplicationController
 
   def login
-    user = User.find_by(email: params[:email])
-    if user&.authenticate(params[:password])
+    user = User.authenticate_by(email: params[:email], password: params[:password])
+    if user
       token = TokenGenerator.encode(user.id)
       cookies[:jwt] = jwt_cookie_options(token)
       render json: { name: user.name, email: user.email }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,9 @@
 class ApplicationController < ActionController::API
   include ActionController::Cookies
   include Rails.application.routes.url_helpers
-  before_action :set_current_user
+  include ActionController::RequestForgeryProtection
+  protect_from_forgery with: :exception
+  before_action :set_current_user, :set_csrf_token
 
   def set_current_user
     token = cookies[:jwt]
@@ -23,6 +25,12 @@ class ApplicationController < ActionController::API
       return
     end
   end
+
+  def set_csrf_token
+    response.set_header('X-CSRF-Token', form_authenticity_token)
+  end
+
+
 
   protected
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -29,11 +29,9 @@ module App
     # Skip views, helpers and assets when generating a new resource.
     config.time_zone = 'Asia/Tokyo'
     config.api_only = true
+    config.action_controller.forgery_protection_origin_check = false
     config.active_job.queue_adapter = :good_job
-    config.middleware.use ActionDispatch::Session::CookieStore
     config.middleware.use ActionDispatch::Cookies
-    config.middleware.use Rack::MethodOverride
-    config.middleware.use ActionDispatch::Flash
-    
+    config.middleware.use ActionDispatch::Session::CookieStore
   end
 end

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -12,6 +12,7 @@ Rails.application.config.middleware.insert_before 0, Rack::Cors do
     resource "/api/v1/*",
       headers: :any,
       methods: [:get, :post, :put, :patch, :delete, :options, :head],
+      expose: ['X-CSRF-Token'],
       credentials: true
   end
 end


### PR DESCRIPTION
- Googleログイン機能のコードを整理
- 認証コントローラーでのユーザー認証方法を変更
- CSRFトークンをレスポンスヘッダーに追加
- CORS設定でCSRFトークンを公開

認証にcookieを使用しているため、csrf対策としてcsrf-tokenを実装した。
組み機能であるform_authenticity_tokenを使用している。
これはcsrf-tokenを自動生成してくれる機能で、内部的にはsession[:csrf-token]に保存されている。
また、session管理もされているため、sessionが変わらなければtokenの再生成はしない。
なお、APIモードのため、使用にはApplication_contorollerでinclude ActionController::RequestForgeryProtection
が必要。

また、headerにtokenは入れて、フロントでもtoken取得をするためにcors設定にexpose: ['X-CSRF-Token']を追加した。
