### PR TITLE
chore: CI設定の更新とGemのバージョン変更

### DIFF
--- a/.github/workflows/my-ci.yml
+++ b/.github/workflows/my-ci.yml
@@ -1,6 +1,5 @@
 name: MY-CI
 on: 
-  pull_request: 
   push:
 
 jobs:
@@ -45,8 +44,6 @@ jobs:
           POSTGRES_PASSWORD: postgres
         ports:
           - 5432:5432
-        options: --health-cmd="pg_isready" --health-interval=10s --health-timeout=5s --health-retries=3
-      
 
     steps:
       - name: パッケージのインストール
@@ -64,5 +61,5 @@ jobs:
       - name: Rspec実行
         env:
           RAILS_ENV: test
-          DATABASE_URL: postgres://postgres:postgres@localhost:5432
+          DATABASE_URL: postgres://postgres:postgres@localhost:5432/app_test
         run: bin/rails db:prepare && bundle exec rspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,7 +82,7 @@ GEM
     bigdecimal (3.1.9)
     bootsnap (1.18.4)
       msgpack (~> 1.2)
-    brakeman (7.0.2)
+    brakeman (7.1.0)
       racc
     builder (3.3.0)
     childprocess (5.1.0)


### PR DESCRIPTION
- CIワークフローからpull_requestトリガーを削除
- PostgreSQLサービスのヘルスチェックオプションを削除
- DATABASE_URLをテスト用データベースに変更
- brakemanのバージョンを7.0.2から7.1.0に更新