### PR TITLE
fix: RSpecテスト実行時のデータベース準備手順を修正

### DIFF
--- a/.github/workflows/my-ci.yml
+++ b/.github/workflows/my-ci.yml
@@ -65,4 +65,7 @@ jobs:
           POSTGRES_HOST: localhost
           DATABASE_URL: postgres://user:password@localhost:5432/app_test
           RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
-        run: bin/rails db:prepare && bundle exec rspec
+        run: |
+          bin/rails db:create 
+          bi/rails db:schema:load
+          bundle exec rspec

--- a/.github/workflows/my-ci.yml
+++ b/.github/workflows/my-ci.yml
@@ -67,5 +67,5 @@ jobs:
           RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
         run: |
           bin/rails db:create 
-          bi/rails db:schema:load
+          bin/rails db:schema:load
           bundle exec rspec

--- a/coverage/.resultset.json
+++ b/coverage/.resultset.json
@@ -1634,6 +1634,6 @@
         "branches": {}
       }
     },
-    "timestamp": 1758814055
+    "timestamp": 1758817159
   }
 }

--- a/coverage/index.html
+++ b/coverage/index.html
@@ -13,7 +13,7 @@
       <img src="./assets/0.13.1/loading.gif" alt="loading"/>
     </div>
     <div id="wrapper" class="hide">
-      <div class="timestamp">Generated <abbr class="timeago" title="2025-09-26T00:27:35+09:00">2025-09-26T00:27:35+09:00</abbr></div>
+      <div class="timestamp">Generated <abbr class="timeago" title="2025-09-26T01:19:19+09:00">2025-09-26T01:19:19+09:00</abbr></div>
       <ul class="group_tabs"></ul>
 
       <div id="content">

--- a/spec/models/shopping_list_spec.rb
+++ b/spec/models/shopping_list_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe ShoppingList, type: :model do
   describe '#updated_days_ago' do
     it '更新が当日であれば今日がかえされる' do
       list = create(:shopping_list)
-      create(:shopping_list_item, shopping_list: list, created_at: Date.today)
+      create(:shopping_list_item, shopping_list: list, created_at: Time.zone.today)
       expect(list.updated_days_ago).to eq('今日')
     end
 


### PR DESCRIPTION
- `bin/rails db:prepare`を`bin/rails db:create`と`bi/rails db:schema:load`に分割